### PR TITLE
Detect only changed files in HEAD commit

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -45,7 +45,7 @@ def lambda_handler(event, context):
         # Previous HEAD SHA-1 id (i.e. the commit right before the HEAD when this function is called)
         beforeCommitSpecifier = ssmClient.get_parameter(Name='beforeCommitSpecifier')['Parameter']['Value']
     except ssmClient.exceptions.ParameterNotFound:
-        # If parameter is not set yet, use HEAD. In this case, the entire files in the repo will be updated to the S3 bucket
+        # If parameter is not set yet, use HEAD. In this case, there will be no update in the S3 bucket
         beforeCommitSpecifier = "HEAD"
 
 

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -32,7 +32,6 @@ def get_blob_list(codecommit, repository, beforeCommitSpecifier, afterCommitSpec
 #     s3BucketName
 #     codecommitRegion
 #     repository
-#     beforeCommitSpecifier
 #
 # TIME OUT: 1 min
 #

--- a/lambda_function.py
+++ b/lambda_function.py
@@ -3,7 +3,26 @@ import os
 import mimetypes
 
 
-# basically returns a list of a all files in the branch
+# returns a list of all files in the branch
+def get_entire_blob_list(codecommit, repository, afterCommitSpecifier):
+    response = codecommit.get_differences(
+        repositoryName=repository,
+        afterCommitSpecifier=afterCommitSpecifier,
+    )
+
+    blob_list = [difference['afterBlob'] for difference in response['differences']]
+    while 'nextToken' in response:
+        response = codecommit.get_differences(
+            repositoryName=repository,
+            afterCommitSpecifier=afterCommitSpecifier,
+            nextToken=response['nextToken']
+        )
+        blob_list += [difference['afterBlob'] for difference in response['differences']]
+
+    return blob_list
+
+
+# returns a list of changed files between beforeCommitSpecifier and afterCommitSpecifier
 def get_blob_list(codecommit, repository, beforeCommitSpecifier, afterCommitSpecifier):
     response = codecommit.get_differences(
         repositoryName=repository,
@@ -39,28 +58,28 @@ def get_blob_list(codecommit, repository, beforeCommitSpecifier, afterCommitSpec
 #     lambda-codecommit-s3-execution-role (permissions: AWSCodeCommitReadOnly, AWSLambdaExecute, AmazonSSMFullAccess)
 #
 def lambda_handler(event, context):
-    ssmClient = boto3.client('ssm')
-
-    try:
-        # Previous HEAD SHA-1 id (i.e. the commit right before the HEAD when this function is called)
-        beforeCommitSpecifier = ssmClient.get_parameter(Name='beforeCommitSpecifier')['Parameter']['Value']
-    except ssmClient.exceptions.ParameterNotFound:
-        # If parameter is not set yet, use HEAD. In this case, there will be no update in the S3 bucket
-        beforeCommitSpecifier = "HEAD"
-
+    repository_name = os.environ['repository']
 
     # Current HEAD SHA-1 id
     head = event['Records'][0]['codecommit']['references'][0]['commit']
+    # source codecommit
+    codecommit = boto3.client('codecommit', region_name=os.environ['codecommitRegion'])
+
+    ssmClient = boto3.client('ssm')
+    ssmParamName = repository_name + "_beforeCommitSpecifier"
+    try:
+        # Previous HEAD SHA-1 id (i.e. the commit right before the HEAD when this function is called)
+        beforeCommitSpecifier = ssmClient.get_parameter(Name=ssmParamName)['Parameter']['Value']
+        blobList = get_blob_list(codecommit, repository_name, beforeCommitSpecifier, head)
+    except ssmClient.exceptions.ParameterNotFound:
+        # If beforeCommitSpecifier is not set, blobList retrieves a list of the entire files
+        blobList = get_entire_blob_list(codecommit, repository_name, head)
 
     # target bucket
     bucket = boto3.resource('s3').Bucket(os.environ['s3BucketName'])
 
-    # source codecommit
-    codecommit = boto3.client('codecommit', region_name=os.environ['codecommitRegion'])
-    repository_name = os.environ['repository']
-
     # reads each file in the branch and uploads it to the s3 bucket
-    for blob in get_blob_list(codecommit, repository_name, beforeCommitSpecifier, head):
+    for blob in blobList:
         path = blob['path']
         content = (codecommit.get_blob(repositoryName=repository_name, blobId=blob['blobId']))['content']
 
@@ -72,4 +91,4 @@ def lambda_handler(event, context):
             bucket.put_object(Body=(content), Key=path)
 
     # Update beforeCommitSpecifier environment variable with the current HEAD
-    ssmClient.put_parameter(Name='beforeCommitSpecifier', Type='String', Value=head, Overwrite=True)
+    ssmClient.put_parameter(Name=ssmParamName, Type='String', Value=head, Overwrite=True)


### PR DESCRIPTION
get_differences API without beforeCommitSpecifier parameter returns the entire files in a repository. It introduces a lot of unnecessary updates in an S3 bucket. I added several lines of code to extract the files that are changed in the HEAD commit and update them only. My change requires extended permission than AWSLambdaExecute since the function need to update the environment variable, beforeCommitSpecifier, at the end of execution.