### PR TITLE
Change 'nextToken' to 'NextToken' per the API docs

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -2,9 +2,8 @@ import boto3
 import os
 import mimetypes
 
-
 # returns a list of the files in the branch or commit
-def get_blob_list(codecommit, repository, afterCommitSpecifier, beforeCommitSpecifier=None, ):
+def get_blob_list(codecommit, repository, afterCommitSpecifier, beforeCommitSpecifier=None):
     args = {'repositoryName': repository, 'afterCommitSpecifier': afterCommitSpecifier}
 
     if beforeCommitSpecifier:
@@ -13,8 +12,9 @@ def get_blob_list(codecommit, repository, afterCommitSpecifier, beforeCommitSpec
     response = codecommit.get_differences(**args)
 
     blob_list = [difference['afterBlob'] for difference in response['differences']]
-    while 'nextToken' in response:
-        args['nextToken'] = response['nextToken']
+
+    while 'NextToken' in response:
+        args['NextToken'] = response['NextToken']
         response = codecommit.get_differences(**args)
         blob_list += [difference['afterBlob'] for difference in response['differences']]
 


### PR DESCRIPTION
Michael - While trying to copy my 1500+ file repo to S3 I noticed get_blob_list wasn't handling the pagination properly.  It was a simple character case issue and notably an inconsistency in the boto3 interface.